### PR TITLE
feat: integrate Essentia and madmom backends

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 aiogram>=3.3.0,<4
 librosa>=0.10.1,<0.11
+essentia>=2.1b6
+madmom>=0.17.0
+tensorflow>=2.13
 numpy>=1.26,<3
 scipy>=1.11,<2
 soundfile>=0.12,<0.14

--- a/src/audio_processing/analyzer.py
+++ b/src/audio_processing/analyzer.py
@@ -6,12 +6,32 @@ import math
 from dataclasses import dataclass
 import logging
 from pathlib import Path
-from typing import Optional, Sequence, Tuple
+from typing import Any, Optional, Sequence, Tuple
 
 import librosa
 import librosa.util
 import numpy as np
 import soundfile as sf
+
+try:  # Optional enhanced key detection backend
+    import essentia.standard as es  # type: ignore
+
+    _ESSENTIA_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    es = None  # type: ignore
+    _ESSENTIA_AVAILABLE = False
+
+try:  # Optional enhanced tempo backend
+    from madmom.audio.signal import Signal  # type: ignore
+    from madmom.features.beats import RNNBeatProcessor  # type: ignore
+    from madmom.features.tempo import TempoEstimationProcessor  # type: ignore
+
+    _MADMOM_AVAILABLE = True
+except Exception:  # pragma: no cover - optional dependency
+    Signal = None  # type: ignore
+    RNNBeatProcessor = None  # type: ignore
+    TempoEstimationProcessor = None  # type: ignore
+    _MADMOM_AVAILABLE = False
 
 from .profiles import ENHARMONIC, MAJOR_PROFILES, MINOR_PROFILES, NOTES_SHARP
 
@@ -23,6 +43,12 @@ CLOSE_KEY_ALT_MIN_CONF = 0.20
 POSITIVE_CORRELATION_THRESHOLD = 0.6
 HARMONIC_HOP_LENGTH = 512
 HARMONIC_RMS_VOID = 1e-5
+
+
+_ESSENTIA_KEY_EXTRACTORS: dict[int, Any] = {}
+_ESSENTIA_RHYTHM_EXTRACTORS: dict[int, Any] = {}
+_MADMOM_BEAT_PROCESSOR: Optional[Any] = None
+_MADMOM_TEMPO_PROCESSOR: Optional[Any] = None
 
 
 def _env_float(name: str, default: float) -> float:
@@ -133,6 +159,443 @@ class AnalysisError(RuntimeError):
     """Raised when audio analysis cannot be completed."""
 
 
+def _normalize_essentia_note(note: str) -> Optional[str]:
+    """Map Essentia note naming to the sharp-based system used by the bot."""
+
+    if not note:
+        return None
+
+    cleaned = note.strip().replace("♯", "#").replace("♭", "b")
+    if not cleaned:
+        return None
+
+    base = cleaned[0].upper()
+    accidental = ""
+    if len(cleaned) > 1:
+        symbol = cleaned[1]
+        if symbol in {"#", "b"}:
+            accidental = symbol
+
+    normalized = f"{base}{accidental}"
+    if normalized in NOTES_SHARP:
+        return normalized
+
+    enharmonic = ENHARMONIC.get(normalized)
+    if enharmonic in NOTES_SHARP:
+        return enharmonic
+    return None
+
+
+def _merge_key_detection(
+    primary: KeyDetectionResult, secondary: KeyDetectionResult
+) -> KeyDetectionResult:
+    return KeyDetectionResult(
+        note=primary.note,
+        mode=primary.mode,
+        correlation=max(primary.correlation, secondary.correlation),
+        score=max(primary.score, secondary.score),
+        positive_support=max(primary.positive_support, secondary.positive_support),
+        dominant_share=max(primary.dominant_share, secondary.dominant_share),
+        confidence=max(primary.confidence, secondary.confidence),
+    )
+
+
+def _get_essentia_key_extractor(sr: int) -> Optional[Any]:
+    if not _ESSENTIA_AVAILABLE or es is None:
+        return None
+
+    extractor = _ESSENTIA_KEY_EXTRACTORS.get(sr)
+    if extractor is not None:
+        return extractor
+
+    candidate_kwargs = [
+        {
+            "profileType": "temperley",
+            "pcpSize": 36,
+            "maxNumPeaks": 10,
+            "windowSize": 0.5,
+            "sampleRate": sr,
+        },
+        {
+            "profileType": "temperley",
+            "pcpSize": 36,
+            "maxNumPeaks": 10,
+            "sampleRate": sr,
+        },
+        {"profileType": "temperley", "pcpSize": 36, "sampleRate": sr},
+        {"profileType": "temperley", "sampleRate": sr},
+        {"profileType": "temperley"},
+        {},
+    ]
+
+    for kwargs in candidate_kwargs:
+        try:
+            extractor = es.KeyExtractor(**kwargs)
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.debug(
+                "Failed to create Essentia KeyExtractor with %s: %s", kwargs, exc
+            )
+            continue
+        _ESSENTIA_KEY_EXTRACTORS[sr] = extractor
+        return extractor
+
+    logger.warning(
+        "Unable to initialise Essentia KeyExtractor for sample rate %s", sr
+    )
+    return None
+
+
+def _get_essentia_rhythm_extractor(sr: int) -> Optional[Any]:
+    if not _ESSENTIA_AVAILABLE or es is None:
+        return None
+
+    extractor = _ESSENTIA_RHYTHM_EXTRACTORS.get(sr)
+    if extractor is not None:
+        return extractor
+
+    candidate_kwargs = [
+        {
+            "method": "multifeature",
+            "minTempo": BPM_MIN,
+            "maxTempo": BPM_MAX,
+            "sampleRate": sr,
+        },
+        {
+            "method": "multifeature",
+            "minTempo": BPM_MIN,
+            "maxTempo": BPM_MAX,
+        },
+        {"method": "multifeature"},
+        {},
+    ]
+
+    for kwargs in candidate_kwargs:
+        try:
+            extractor = es.RhythmExtractor2013(**kwargs)
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.debug(
+                "Failed to create Essentia RhythmExtractor with %s: %s", kwargs, exc
+            )
+            continue
+        _ESSENTIA_RHYTHM_EXTRACTORS[sr] = extractor
+        return extractor
+
+    logger.warning(
+        "Unable to initialise Essentia RhythmExtractor for sample rate %s", sr
+    )
+    return None
+
+
+def _get_madmom_processors() -> tuple[Optional[Any], Optional[Any]]:
+    if not _MADMOM_AVAILABLE or RNNBeatProcessor is None or TempoEstimationProcessor is None:
+        return None, None
+
+    global _MADMOM_BEAT_PROCESSOR, _MADMOM_TEMPO_PROCESSOR
+
+    if _MADMOM_BEAT_PROCESSOR is None:
+        try:
+            _MADMOM_BEAT_PROCESSOR = RNNBeatProcessor()
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.debug("Failed to initialise madmom beat processor: %s", exc)
+            return None, None
+
+    if _MADMOM_TEMPO_PROCESSOR is None:
+        try:
+            _MADMOM_TEMPO_PROCESSOR = TempoEstimationProcessor(fps=100)
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.debug("Failed to initialise madmom tempo processor: %s", exc)
+            return None, None
+
+    return _MADMOM_BEAT_PROCESSOR, _MADMOM_TEMPO_PROCESSOR
+
+
+def _detect_key_essentia(
+    y_harm: np.ndarray, sr: int
+) -> Optional[KeyDetectionResult]:
+    if not _ESSENTIA_AVAILABLE or es is None:
+        return None
+    if y_harm.size == 0 or not np.any(y_harm):
+        return None
+
+    extractor = _get_essentia_key_extractor(sr)
+    if extractor is None:
+        return None
+
+    audio = np.ascontiguousarray(y_harm, dtype=np.float32)
+    try:
+        raw_result = extractor(audio)
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(f"Essentia key extraction failed: {exc}") from exc
+
+    key_raw: Any = None
+    scale_raw: Any = "major"
+    strength_raw: Any = 0.0
+
+    if isinstance(raw_result, (tuple, list)):
+        if raw_result:
+            key_raw = raw_result[0]
+        if len(raw_result) >= 2:
+            scale_raw = raw_result[1]
+        if len(raw_result) >= 3:
+            strength_raw = raw_result[2]
+    else:
+        key_raw = raw_result
+
+    if key_raw is None:
+        return None
+
+    key_text = str(key_raw)
+    if " " in key_text:
+        key_part = key_text.split()[0]
+    else:
+        key_part = key_text
+
+    normalized_note = _normalize_essentia_note(key_part)
+    if normalized_note is None:
+        logger.debug("Unable to normalise Essentia key %s", key_text)
+        return None
+
+    mode_text = str(scale_raw).lower()
+    mode = "Maj" if mode_text.startswith("maj") else "min"
+
+    try:
+        strength_value = float(strength_raw)
+    except (TypeError, ValueError):
+        strength_value = 0.0
+
+    if math.isnan(strength_value):
+        strength_value = 0.0
+
+    strength_value = float(np.clip(strength_value, 0.0, 1.0))
+    confidence = float(np.clip(strength_value * 1.25, 0.0, 1.0))
+
+    logger.debug(
+        "Essentia key candidate %s%s (strength %.3f, confidence %.3f)",
+        normalized_note,
+        mode,
+        strength_value,
+        confidence,
+    )
+
+    return KeyDetectionResult(
+        note=normalized_note,
+        mode=mode,
+        correlation=strength_value,
+        score=strength_value,
+        positive_support=strength_value,
+        dominant_share=strength_value,
+        confidence=confidence,
+    )
+
+
+def _combine_key_candidates(
+    fallback_best: KeyDetectionResult,
+    fallback_candidates: Sequence[KeyDetectionResult],
+    essentia_candidate: KeyDetectionResult,
+) -> tuple[KeyDetectionResult, list[KeyDetectionResult]]:
+    candidates = list(fallback_candidates)
+
+    match_idx: Optional[int] = None
+    for idx, candidate in enumerate(candidates):
+        if candidate.note == essentia_candidate.note and candidate.mode == essentia_candidate.mode:
+            match_idx = idx
+            break
+
+    if match_idx is not None:
+        merged_candidate = _merge_key_detection(
+            candidates[match_idx], essentia_candidate
+        )
+        candidates[match_idx] = merged_candidate
+        essentia_candidate = merged_candidate
+    else:
+        candidates.insert(0, essentia_candidate)
+
+    same_key = (
+        fallback_best.note == essentia_candidate.note
+        and fallback_best.mode == essentia_candidate.mode
+    )
+
+    if same_key:
+        merged_best = _merge_key_detection(fallback_best, essentia_candidate)
+        for idx, candidate in enumerate(candidates):
+            if candidate.note == merged_best.note and candidate.mode == merged_best.mode:
+                candidates[idx] = merged_best
+                break
+        return merged_best, candidates
+
+    if fallback_best.confidence < CONF_VOID and essentia_candidate.confidence >= CONF_VOID:
+        logger.debug(
+            "Switching to Essentia key %s%s due to low confidence fallback (%.2f)",
+            essentia_candidate.note,
+            essentia_candidate.mode,
+            fallback_best.confidence,
+        )
+        return essentia_candidate, candidates
+
+    if essentia_candidate.confidence >= fallback_best.confidence + 0.1:
+        logger.debug(
+            "Switching to Essentia key %s%s (conf %.2f) over librosa %s%s (conf %.2f)",
+            essentia_candidate.note,
+            essentia_candidate.mode,
+            essentia_candidate.confidence,
+            fallback_best.note,
+            fallback_best.mode,
+            fallback_best.confidence,
+        )
+        return essentia_candidate, candidates
+
+    return fallback_best, candidates
+
+
+def _detect_key(
+    y_harm: np.ndarray, sr: int
+) -> Tuple[KeyDetectionResult, list[KeyDetectionResult], float]:
+    best, candidates, tuning = _detect_key_librosa(y_harm, sr)
+
+    if not _ESSENTIA_AVAILABLE or es is None:
+        return best, candidates, tuning
+
+    try:
+        essentia_candidate = _detect_key_essentia(y_harm, sr)
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logger.debug("Essentia key detection failed: %s", exc)
+        return best, candidates, tuning
+
+    if essentia_candidate is None:
+        return best, candidates, tuning
+
+    best_combined, combined_candidates = _combine_key_candidates(
+        best, candidates, essentia_candidate
+    )
+    return best_combined, combined_candidates, tuning
+
+
+def _detect_bpm_madmom(y: np.ndarray, sr: int) -> Tuple[int, int, int]:
+    if not _MADMOM_AVAILABLE or Signal is None:
+        return 0, 0, 0
+    if y.size == 0 or not np.any(y):
+        return 0, 0, 0
+
+    beat_processor, tempo_processor = _get_madmom_processors()
+    if beat_processor is None or tempo_processor is None:
+        return 0, 0, 0
+
+    try:
+        signal = Signal(y, sample_rate=sr)
+        activations = beat_processor(signal)
+        tempo_candidates = tempo_processor(activations)
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(f"madmom tempo estimation failed: {exc}") from exc
+
+    tempo_array = np.asarray(tempo_candidates, dtype=float)
+    if tempo_array.size == 0:
+        return 0, 0, 0
+
+    if tempo_array.ndim >= 2:
+        bpm_value = float(tempo_array[0][0])
+        bpm_candidates = tempo_array[:, 0]
+    else:
+        bpm_value = float(tempo_array[0])
+        bpm_candidates = tempo_array
+
+    if math.isnan(bpm_value) or bpm_value <= 0:
+        return 0, 0, 0
+
+    bpm_int = int(round(bpm_value))
+    bpm_adjusted = _adjust_bpm(bpm_int, bpm_candidates)
+
+    bpm = bpm_adjusted
+    bpm_double = int(round(bpm * 2)) if bpm else 0
+    bpm_half = int(round(bpm / 2)) if bpm else 0
+    return bpm, bpm_double, bpm_half
+
+
+def _detect_bpm_essentia(y: np.ndarray, sr: int) -> Tuple[int, int, int]:
+    if not _ESSENTIA_AVAILABLE or es is None:
+        return 0, 0, 0
+    if y.size == 0 or not np.any(y):
+        return 0, 0, 0
+
+    extractor = _get_essentia_rhythm_extractor(sr)
+    if extractor is None:
+        return 0, 0, 0
+
+    audio = np.ascontiguousarray(y, dtype=np.float32)
+    try:
+        raw_result = extractor(audio)
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError(f"Essentia tempo extraction failed: {exc}") from exc
+
+    bpm_value = 0.0
+    beat_intervals: Optional[np.ndarray] = None
+
+    if isinstance(raw_result, (tuple, list)):
+        if raw_result:
+            bpm_value = float(raw_result[0])
+        if len(raw_result) >= 5:
+            beat_intervals = np.asarray(raw_result[4], dtype=float)
+        elif len(raw_result) >= 3 and isinstance(raw_result[2], (list, np.ndarray)):
+            beat_intervals = np.asarray(raw_result[2], dtype=float)
+    else:
+        bpm_value = float(raw_result)
+
+    if math.isnan(bpm_value) or bpm_value <= 0:
+        return 0, 0, 0
+
+    bpm_int = int(round(bpm_value))
+    tempo_candidates: Optional[np.ndarray] = None
+
+    if beat_intervals is not None and beat_intervals.size:
+        with np.errstate(divide="ignore", invalid="ignore"):
+            tempo_candidates = 60.0 / beat_intervals
+        if tempo_candidates is not None:
+            tempo_candidates = tempo_candidates[np.isfinite(tempo_candidates)]
+            if tempo_candidates.size == 0:
+                tempo_candidates = None
+
+    bpm_adjusted = _adjust_bpm(bpm_int, tempo_candidates)
+
+    bpm = bpm_adjusted
+    bpm_double = int(round(bpm * 2)) if bpm else 0
+    bpm_half = int(round(bpm / 2)) if bpm else 0
+    return bpm, bpm_double, bpm_half
+
+
+def _detect_bpm(
+    y_perc: np.ndarray,
+    sr: int,
+    *,
+    y_harm: Optional[np.ndarray] = None,
+    y_original: Optional[np.ndarray] = None,
+) -> Tuple[int, int, int]:
+    if _MADMOM_AVAILABLE and Signal is not None and y_original is not None and y_original.size:
+        try:
+            bpm, bpm_double, bpm_half = _detect_bpm_madmom(y_original, sr)
+            if bpm:
+                return bpm, bpm_double, bpm_half
+        except Exception as exc:  # pragma: no cover - optional dependency
+            logger.debug("Madmom BPM detection failed: %s", exc)
+
+    if _ESSENTIA_AVAILABLE and es is not None:
+        target = None
+        if y_perc is not None and y_perc.size:
+            target = y_perc
+        elif y_original is not None and y_original.size:
+            target = y_original
+        elif y_harm is not None and y_harm.size:
+            target = y_harm
+
+        if target is not None:
+            try:
+                bpm, bpm_double, bpm_half = _detect_bpm_essentia(target, sr)
+                if bpm:
+                    return bpm, bpm_double, bpm_half
+            except Exception as exc:  # pragma: no cover - optional dependency
+                logger.debug("Essentia BPM detection failed: %s", exc)
+
+    return _detect_bpm_librosa(y_perc, sr, y_harm=y_harm, y_original=y_original)
+
+
 def _load_audio(audio_path: Path) -> tuple[np.ndarray, int]:
     """Load audio file, falling back to soundfile if needed."""
 
@@ -241,7 +704,7 @@ def analyze_file(path: str | Path, *, want_close_key: bool = False) -> AnalysisR
     return result
 
 
-def _detect_key(
+def _detect_key_librosa(
     y_harm: np.ndarray, sr: int
 ) -> Tuple[KeyDetectionResult, list[KeyDetectionResult], float]:
     """Detect the musical key using harmonic chroma analysis."""
@@ -529,7 +992,7 @@ def _estimate_bpm_from_signal(
     return bpm
 
 
-def _detect_bpm(
+def _detect_bpm_librosa(
     y_perc: np.ndarray,
     sr: int,
     *,


### PR DESCRIPTION
## Summary
- add optional Essentia-based key detection and madmom rhythm estimation to the audio analyzer
- cascade between the new backends and the existing librosa implementation to keep behaviour stable
- add Essentia, madmom and TensorFlow to the Python requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d33f2193848329b21db98992c06281